### PR TITLE
support import projects by file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .idea/
 *.iml
 bin/
+repository_list.txt

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -49,6 +49,12 @@ var BaseCommands = []cli.Command{
 				Usage:       "Imports a github project",
 				Description: "Imports a github project to Vastness",
 				ArgsUsage:   "REMOTE_URL BRANCH",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  CreateFlagName(FileFlag, FileShortFlag),
+						Usage: FileFlagUsage,
+					},
+				},
 			},
 			{
 				Name:        "bitbucket-server",
@@ -56,6 +62,12 @@ var BaseCommands = []cli.Command{
 				Usage:       "Imports a bitbucket server project",
 				Description: "Imports a bitbucket server project to Vastness",
 				ArgsUsage:   "REMOTE_URL BRANCH",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  CreateFlagName(FileFlag, FileShortFlag),
+						Usage: FileFlagUsage,
+					},
+				},
 			},
 		},
 	},

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -54,6 +54,10 @@ var BaseCommands = []cli.Command{
 						Name:  CreateFlagName(FileFlag, FileShortFlag),
 						Usage: FileFlagUsage,
 					},
+					cli.IntFlag{
+						Name:  CreateFlagName(MaxConcurrentFlag, MaxConcurrentShortFlag),
+						Value: 1,
+					},
 				},
 			},
 			{
@@ -66,6 +70,10 @@ var BaseCommands = []cli.Command{
 					cli.StringFlag{
 						Name:  CreateFlagName(FileFlag, FileShortFlag),
 						Usage: FileFlagUsage,
+					},
+					cli.IntFlag{
+						Name:  CreateFlagName(MaxConcurrentFlag, MaxConcurrentShortFlag),
+						Value: 1,
 					},
 				},
 			},

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -8,4 +8,7 @@ const (
 	BaseCommandDescribe = "describe"
 	CoordinatorFlagName = "coordinator"
 	TimeOut             = 10 * time.Second
+	FileFlag            = "file"
+	FileShortFlag       = "f"
+	FileFlagUsage       = "Reads a list of projects from a file"
 )

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -3,12 +3,15 @@ package cmd
 import "time"
 
 const (
-	BaseCommandGet      = "get"
-	BaseCommandImport   = "import"
-	BaseCommandDescribe = "describe"
-	CoordinatorFlagName = "coordinator"
-	TimeOut             = 10 * time.Second
-	FileFlag            = "file"
-	FileShortFlag       = "f"
-	FileFlagUsage       = "Reads a list of projects from a file"
+	BaseCommandGet         = "get"
+	BaseCommandImport      = "import"
+	BaseCommandDescribe    = "describe"
+	CoordinatorFlagName    = "coordinator"
+	TimeOut                = 10 * time.Second
+	MaxRecvMsgSize         = 1024 * 1024 * 20
+	MaxConcurrentFlag      = "max-concurrent"
+	MaxConcurrentShortFlag = "mc"
+	FileFlag               = "file"
+	FileShortFlag          = "f"
+	FileFlagUsage          = "Reads a list of projects from a file"
 )

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/urfave/cli"
+	"strings"
 )
 
 var (
@@ -14,7 +15,34 @@ var (
 	MalformedRemoteVcsURLErr = cli.NewExitError("Unable to detect vcs from remote url.", 1)
 	APIServerUnavailableErr  = cli.NewExitError("Can't connect to the coordinator.", 1)
 	RenderAsJSONErr          = cli.NewExitError("Unable to render projects as json.", 1)
+	InvalidFileFormat        = cli.NewExitError("Invalid file format.", 1)
 	GenericExitErr           = func(err error) error {
 		return cli.NewExitError(fmt.Sprintf("something went wrong, %s", err.Error()), 1)
 	}
 )
+
+type AggregatedError struct {
+	errors []error
+}
+
+func (e *AggregatedError) Add(err error) *AggregatedError {
+	if err != nil {
+		e.errors = append(e.errors, err)
+	}
+	return e
+}
+
+func (e *AggregatedError) ToError() error {
+	if len(e.errors) == 0 {
+		return nil
+	}
+	return e
+}
+
+func (e *AggregatedError) Error() string {
+	b := strings.Builder{}
+	for _, err := range e.errors {
+		b.WriteString(fmt.Sprintf("<%s>\n", err.Error()))
+	}
+	return b.String()
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -7,8 +7,10 @@ import (
 	"github.com/urfave/cli"
 	toolkit "github.com/vastness-io/toolkit/pkg/grpc"
 	"github.com/vastness-io/vastctl/pkg/import"
+	"github.com/vastness-io/vastctl/pkg/in"
 	webhook "github.com/vastness-io/vcs-webhook-svc/webhook"
 	"google.golang.org/grpc"
+	"strings"
 )
 
 func GitAction(vcsType string) cli.ActionFunc {
@@ -17,61 +19,136 @@ func GitAction(vcsType string) cli.ActionFunc {
 		var (
 			tracer      = opentracing.GlobalTracer()
 			coordinator = ctx.GlobalString(CoordinatorFlagName)
+			useFile     = ctx.String(FileFlag)
 		)
 
-		remoteURl, version, err := validateImportArgs(ctx.Args())
+		var (
+			importProjects []*importing.ImportProjectInfo
+			err            error
+		)
+
+		if useFile != "" {
+			importProjects, err = parseImportFile(useFile)
+		} else {
+			importProjects, err = validateImportArgs(ctx.Args(), nil)
+		}
 
 		if err != nil {
 			return err
 		}
 
-		s := NewSpinner(fmt.Sprintf("importing %s", remoteURl), "")
+		aggregatedError := &AggregatedError{}
 
-		s.Start()
+		for _, project := range importProjects {
+			err := func() error {
 
-		repoImporter, err := importing.NewVcs(remoteURl, version)
+				s := NewSpinner(fmt.Sprintf("importing %s", project.RemoteURL), "")
 
-		if err != nil {
-			return err
+				s.Start()
+
+				defer s.Stop()
+
+				repoImporter, err := importing.NewVcs(project.RemoteURL, project.RemoteURL)
+
+				if err != nil {
+					return err
+				}
+
+				event, err := repoImporter.MapToPushEvent(vcsType)
+
+				if err != nil {
+					return err
+				}
+
+				coordinatorConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure())(coordinator)
+
+				if err != nil {
+					return err
+				}
+
+				defer coordinatorConn.Close()
+
+				cc := webhook.NewVcsEventClient(coordinatorConn)
+
+				httpCtx, cancelFunc := context.WithTimeout(context.Background(), TimeOut)
+
+				defer cancelFunc()
+
+				_, err = cc.OnPush(httpCtx, event)
+
+				return err
+			}()
+
+			aggregatedError.Add(err)
+
 		}
 
-		event, err := repoImporter.MapToPushEvent(vcsType)
-
-		if err != nil {
-			return err
-		}
-
-		coordinatorConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure())(coordinator)
-
-		if err != nil {
-			return err
-		}
-
-		defer coordinatorConn.Close()
-
-		cc := webhook.NewVcsEventClient(coordinatorConn)
-
-		httpCtx, cancelFunc := context.WithTimeout(context.Background(), TimeOut)
-
-		defer cancelFunc()
-
-		_, err = cc.OnPush(httpCtx, event)
-
-		s.Stop()
-
-		return err
+		return aggregatedError.ToError()
 	}
 }
-func validateImportArgs(args cli.Args) (remoteURL, version string, err error) {
-	if len(args) == 1 {
-		remoteURL = args[0]
-	} else if len(args) >= 2 {
-		remoteURL = args[0]
-		version = args[1]
-	} else {
-		err = MissingRemoteURLErr
+
+func parseImportFile(file string) ([]*importing.ImportProjectInfo, error) {
+
+	fileContents, err := in.ReadFile(file)
+
+	if err != nil {
+		return nil, err
 	}
 
-	return
+	lines := strings.Split(strings.TrimSuffix(fileContents, "\n"), "\n")
 
+	if len(lines) == 0 || lines[0] == "" {
+		return nil, InvalidFileFormat
+	}
+
+	out := make([]*importing.ImportProjectInfo, len(lines))
+
+	for i, _ := range lines {
+		const (
+			remoteURL = iota
+			version
+		)
+
+		fields := strings.Fields(lines[i])
+
+		if len(fields) == 1 {
+			out[i] = &importing.ImportProjectInfo{
+				RemoteURL: fields[remoteURL],
+			}
+		} else if len(fields) >= 2 {
+			out[i] = &importing.ImportProjectInfo{
+				RemoteURL: fields[remoteURL],
+				Version:   fields[version],
+			}
+		}
+	}
+
+	return out, nil
+}
+
+func validateImportArgs(args cli.Args, importProjects []*importing.ImportProjectInfo) ([]*importing.ImportProjectInfo, error) {
+
+	const (
+		remoteURL = iota
+		version
+	)
+	out := make([]*importing.ImportProjectInfo, 0)
+
+	if len(args) == 0 {
+		if importProjects == nil {
+			return nil, MissingRemoteURLErr
+		} else {
+			return importProjects, nil
+		}
+	} else if len(args) == 1 {
+		out = append(out, &importing.ImportProjectInfo{
+			RemoteURL: args[remoteURL],
+		})
+	} else if len(args) >= 2 {
+		out = append(out, &importing.ImportProjectInfo{
+			RemoteURL: args[remoteURL],
+			Version:   args[version],
+		})
+	}
+	return validateImportArgs(args.Tail(), out)
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -20,7 +20,7 @@ func getProjects() func(*cli.Context) error {
 			tracer  = opentracing.GlobalTracer()
 		)
 
-		clientConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure())(address)
+		clientConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(-1)))(address)
 
 		if err != nil {
 			return err

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -20,7 +20,7 @@ func getProjects() func(*cli.Context) error {
 			tracer  = opentracing.GlobalTracer()
 		)
 
-		clientConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(-1)))(address)
+		clientConn, err := toolkit.NewGRPCClient(tracer, nil, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)))(address)
 
 		if err != nil {
 			return err

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/briandowns/spinner"
 	"github.com/masterminds/vcs"
 	"github.com/urfave/cli"
 	"github.com/vastness-io/coordinator-svc/project"
+	"github.com/vastness-io/vastctl/pkg/import"
 	"github.com/vastness-io/vastctl/pkg/shared"
 	vcs2 "github.com/vastness-io/vcs-webhook-svc/webhook"
 	"google.golang.org/grpc/codes"
@@ -63,6 +65,10 @@ func MapVcsTypesToVcsMessage(vcsType string) (string, error) {
 	}
 }
 
+func CreateFlagName(full, short string) string {
+	return fmt.Sprintf("%s, %s", full, short)
+}
+
 func NewSpinner(prefix, finalMsg string) *spinner.Spinner {
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Prefix = prefix
@@ -72,4 +78,12 @@ func NewSpinner(prefix, finalMsg string) *spinner.Spinner {
 	}
 	return s
 
+}
+
+func Take(n int, projects []*importing.ImportProjectInfo) ([]*importing.ImportProjectInfo, []*importing.ImportProjectInfo) {
+	projectsLen := len(projects)
+
+	if n < projectsLen {
+		return append()
+	}
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -80,10 +80,21 @@ func NewSpinner(prefix, finalMsg string) *spinner.Spinner {
 
 }
 
-func Take(n int, projects []*importing.ImportProjectInfo) ([]*importing.ImportProjectInfo, []*importing.ImportProjectInfo) {
-	projectsLen := len(projects)
+func ChunkImportProjects(importProjects []*importing.ImportProjectInfo, n int) [][]*importing.ImportProjectInfo {
 
-	if n < projectsLen {
-		return append()
+	var groups [][]*importing.ImportProjectInfo
+
+	chunkSize := n
+
+	for i := 0; i < len(importProjects); i += chunkSize {
+		end := i + chunkSize
+
+		if end > len(importProjects) {
+			end = len(importProjects)
+		}
+
+		groups = append(groups, importProjects[i:end])
 	}
+
+	return groups
 }

--- a/hack/import-bitbucket-server-projects.sh
+++ b/hack/import-bitbucket-server-projects.sh
@@ -1,0 +1,9 @@
+SERVER=$1
+USER=$2
+PASS=$3
+# Error could be due to bitbucket locking your session, log in via ui and enter CAPTCHA
+curl -u ${USER}:${PASS} -k -s https://${SERVER}/rest/api/1.0/projects/ | jq -r ".values[].key" | while read line
+do
+   curl -u ${USER}:${PASS} -k -s https://${SERVER}/rest/api/1.0/projects/${line}/repos | jq -r ".values[].links.clone[] | select(.name == \"http\") | .href" >> repository_list.txt
+done
+

--- a/pkg/import/git_vcs.go
+++ b/pkg/import/git_vcs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/masterminds/vcs"
 	"github.com/vastness-io/vastctl/pkg/shared"
 	event "github.com/vastness-io/vcs-webhook-svc/webhook"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -17,11 +16,7 @@ type gitVcs struct {
 
 func (g *gitVcs) MapToPushEvent(vcsType string) (*event.VcsPushEvent, error) {
 
-	defer func() {
-		if rerr := os.RemoveAll(g.LocalPath()); rerr != nil {
-			fmt.Printf("failed to remove temp path: %s", g.LocalPath())
-		}
-	}()
+	defer CleanupTemporaryImportDir(g.LocalPath())
 
 	ev, err := WalkGitTree(g, vcsType)
 

--- a/pkg/import/git_vcs.go
+++ b/pkg/import/git_vcs.go
@@ -6,9 +6,9 @@ import (
 	"github.com/vastness-io/vastctl/pkg/shared"
 	event "github.com/vastness-io/vcs-webhook-svc/webhook"
 	"os"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 )
 
 type gitVcs struct {
@@ -169,12 +169,11 @@ func createPushCommit(sha, fileString string) *event.PushCommit {
 
 			if nameStatus := strings.Fields(file); len(nameStatus) != 0 {
 
-
 				status := nameStatus[status]
 
-				renamedRegex := regexp.MustCompile(`^R.*$`)
+				renamedRegex := regexp.MustCompile(`^R[0-9]+$`)
 
-				switch  {
+				switch {
 
 				case status == "A":
 					out.Added = append(out.Added, nameStatus[name])
@@ -185,8 +184,7 @@ func createPushCommit(sha, fileString string) *event.PushCommit {
 				case renamedRegex.MatchString(status):
 					out.Removed = append(out.Removed, nameStatus[name])
 					out.Added = append(out.Added, nameStatus[renamedName])
-
-				case status == "D":
+				case status == "D" || status == "RM":
 					out.Removed = append(out.Removed, nameStatus[name])
 				}
 			}

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -4,6 +4,11 @@ import (
 	event "github.com/vastness-io/vcs-webhook-svc/webhook"
 )
 
+type ImportProjectInfo struct {
+	RemoteURL string
+	Version   string
+}
+
 type RepoImporter interface {
 	MapToPushEvent(vcsType string) (*event.VcsPushEvent, error)
 }

--- a/pkg/import/util.go
+++ b/pkg/import/util.go
@@ -1,8 +1,10 @@
 package importing
 
 import (
+	"fmt"
 	"github.com/vastness-io/vastctl/pkg/shared"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -26,4 +28,10 @@ func SplitVcsRemoteUrl(remoteURL string) (owner string, repository string, err e
 
 	return "", "", shared.InvalidVcsRemoteURL
 
+}
+
+func CleanupTemporaryImportDir(filePath string) {
+	if rerr := os.RemoveAll(filePath); rerr != nil {
+		fmt.Printf("failed to remove temp path: %s\n", filePath)
+	}
 }

--- a/pkg/in/file.go
+++ b/pkg/in/file.go
@@ -1,0 +1,32 @@
+package in
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func ReadFile(filename string) (string, error) {
+
+	var file io.Reader
+
+	if filename == "-" {
+		file = os.Stdin
+	} else {
+		reader, err := os.Open(filename)
+
+		if err != nil {
+			return "", err
+		}
+
+		file = reader
+	}
+
+	b, err := ioutil.ReadAll(file)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}


### PR DESCRIPTION
fixes #5 

This allows importing of projects via file and stdin with the following format
```
REMOTEURL VERSION
```
Note: version is optional!
 
Usage
`vastctl import github -f $FILE`
or
`vastctl import bitbucket-server -f $FILE`

example file:

```
https://github.com/vastness-io/coordinator.git 0.1.0
https://github.com/pazuzu-io/pazuzu-registry
```